### PR TITLE
支持自定义 http client & 支持退出实例

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ func wxApiPost(c echo.Context) error {
 	)
 ```
 
+## 退出
+
+在多微信 app 的情况下, 修改了微信的配置之后, 需要动态地调整微信配置, 这时候需要结束老的实例, 可以调用实例的 Stop 方法.
+
+```go
+app.Stop() // Stop 可多次调用
+
+app.AddMsg(app.NewText("zhengzhou", "这条消息不会被发出, 因为在 Stop 方法后, 后台发送消息的 goroutine 已经退出"))  
+
+```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ func main() {
 	}
 ```
 
+### 定制 HTTP client
+
+```go
+import "github.com/esap/wechat/util"
+
+func myCustomHTTPClient() *http.Client {
+	// 配置适合自己部署环境的 HTTP client, 例如超时, 代理(可能需要认证)等
+	tr := &http.Transport{
+		MaxIdleConns:       10,
+		IdleConnTimeout:    30 * time.Second,
+		DisableCompression: true,
+	}
+	return &http.Client{Transport: tr}
+}
+
+util.SetHTTPClientFactory(myCustomHTTPClient)
+
+```
+
+
 ## 主动推送消息
 
 用户关注后，企业微信可以主动推送消息，服务号需要用户48小时内进入过。
@@ -237,6 +257,7 @@ func wxApiPost(c echo.Context) error {
 		tlpdata,
 	)
 ```
+
 
 ## License
 

--- a/send.go
+++ b/send.go
@@ -10,6 +10,14 @@ import (
 
 // AddMsg 添加队列消息
 func (s *Server) AddMsg(v interface{}) {
+	select {
+	case <-s.stopCh:
+		// do not add message to queue if the server is down
+		Println("[*] 试图在微信服务关闭的情况下发消息")
+		return
+	default:
+	}
+
 	s.MsgQueue <- v
 }
 

--- a/util/http.go
+++ b/util/http.go
@@ -18,13 +18,24 @@ import (
 // TimeOut 全局请求超时设置,默认1分钟
 var TimeOut time.Duration = 60 * time.Second
 
+// 全局获取 http client 的方法
+var httpClient func() *http.Client
+
+func init() {
+	httpClient = defaultHTTPClient
+}
+
 // SetTimeOut 设置全局请求超时
 func SetTimeOut(d time.Duration) {
 	TimeOut = d
 }
 
+func SetHTTPClientFactory(f func() *http.Client) {
+	httpClient = f
+}
+
 // httpClient() 带超时的http.Client
-func httpClient() *http.Client {
+func defaultHTTPClient() *http.Client {
 	return &http.Client{Timeout: TimeOut}
 }
 


### PR DESCRIPTION
1. 支持完全自定义 HTTP client (场景: 一些公司容器内部署的服务, 无法直接访问外网, 需要走内部代理, 因此需要自定义 http client)

2. 管理多实例的时候, 如果某个实例的配置经过修改, 这时候停止老的实例, 在 Server 上提供了 Stop 方法