### PR TITLE
修复企业微信使用固定部门ID同步用户信息的问题

### DIFF
--- a/corp_user.go
+++ b/corp_user.go
@@ -14,7 +14,7 @@ const (
 	CorpAPIGetUserOauth = CorpAPI + "user/getuserinfo?access_token=%s&code=%s"
 
 	// CorpAPIUserList 企业微信用户列表
-	CorpAPIUserList       = CorpAPI + `user/list?access_token=%s&department_id=1&fetch_child=1`
+	CorpAPIUserList       = CorpAPI + `user/list?access_token=%s&department_id=%d&fetch_child=1`
 	CorpAPIUserSimpleList = CorpAPI + `user/simplelist?access_token=%s&department_id=1&fetch_child=1`
 
 	// CorpAPIUserGet 企业微信用户接口
@@ -162,11 +162,19 @@ func (s *Server) SyncUserList() (err error) {
 
 // GetUserList 获取用户详情列表
 func (s *Server) GetUserList() (u userList, err error) {
-	url := fmt.Sprintf(CorpAPIUserList, s.GetUserAccessToken())
-	if err = util.GetJson(url, &u); err != nil {
-		return
+	for _, v := range s.DeptList.Department {
+		var tmp userList
+		url := fmt.Sprintf(CorpAPIUserList, s.GetUserAccessToken(), v.Id)
+		if err = util.GetJson(url, &tmp); err != nil {
+			return
+		}
+		if tmp.Error() != nil {
+			err = tmp.Error()
+			u.WxErr = tmp.WxErr
+		}else{
+			u.UserList = append(u.UserList, tmp.UserList...)
+		}
 	}
-	err = u.Error()
 	return
 }
 


### PR DESCRIPTION
你好：
	原本的部门ID是固定为1的。现在更改为通过获取到的部门列表来查询用户。
	不过如果使用者用了嵌套的部门，可能会有一部分重复的用户，后面可能需要再加用户去重的功能。