### PR TITLE
fix:aesencrypt pkcs7pad bug

### DIFF
--- a/util/crypto.go
+++ b/util/crypto.go
@@ -34,9 +34,7 @@ func PKCS7UnPad(msg []byte) []byte {
 // AesEncrypt AES-CBC加密+PKCS#7打包，传入明文和密钥
 func AesEncrypt(src []byte, key []byte) ([]byte, error) {
 	k := len(key)
-	if len(src)%k != 0 {
-		src = PKCS7Pad(src, k)
-	}
+	src = PKCS7Pad(src, k)
 
 	block, err := aes.NewCipher(key)
 	if err != nil {


### PR DESCRIPTION
使用本库做企业微信应用被动消息回复，当消息体长度为密钥长度整倍数时，原代码未做PKCS7Pad，腾讯服务器会解密失败，亦无消息返回，去除原代码AesEbcrypt函数中的长度判断，无论是否整倍数都做pad，就正常了